### PR TITLE
feat: Add optimization feature for composite cursors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ version: "3"
 services: 
   postgres:
     image: postgres:11-alpine
+    command:
+      - -c
+      - log_statement=all
     ports:
       - 8765:5432
     environment: 

--- a/paginator/option.go
+++ b/paginator/option.go
@@ -1,9 +1,17 @@
 package paginator
 
+type Flag string
+
+const (
+	ENABLED  Flag = "ENABLED"
+	DISABLED Flag = "DISABLED"
+)
+
 var defaultConfig = Config{
-	Keys:  []string{"ID"},
-	Limit: 10,
-	Order: DESC,
+	Keys:     []string{"ID"},
+	Limit:    10,
+	Order:    DESC,
+	TupleCmp: DISABLED,
 }
 
 // Option for paginator
@@ -13,12 +21,13 @@ type Option interface {
 
 // Config for paginator
 type Config struct {
-	Rules  []Rule
-	Keys   []string
-	Limit  int
-	Order  Order
-	After  string
-	Before string
+	Rules    []Rule
+	Keys     []string
+	Limit    int
+	Order    Order
+	After    string
+	Before   string
+	TupleCmp Flag
 }
 
 // Apply applies config to paginator
@@ -41,6 +50,9 @@ func (c *Config) Apply(p *Paginator) {
 	}
 	if c.Before != "" {
 		p.SetBeforeCursor(c.Before)
+	}
+	if c.TupleCmp != "" {
+		p.SetAllowTupleCmp(c.TupleCmp == ENABLED)
 	}
 }
 
@@ -83,5 +95,12 @@ func WithAfter(c string) Option {
 func WithBefore(c string) Option {
 	return &Config{
 		Before: c,
+	}
+}
+
+// WithAllowTupleCmp enables tuple comparison optimization
+func WithTupleCmp(flag Flag) Option {
+	return &Config{
+		TupleCmp: flag,
 	}
 }

--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -22,10 +22,11 @@ func New(opts ...Option) *Paginator {
 
 // Paginator a builder doing pagination
 type Paginator struct {
-	cursor Cursor
-	rules  []Rule
-	limit  int
-	order  Order
+	cursor        Cursor
+	rules         []Rule
+	limit         int
+	order         Order
+	allowTupleCmp bool
 }
 
 // SetRules sets paging rules
@@ -63,6 +64,11 @@ func (p *Paginator) SetAfterCursor(afterCursor string) {
 // SetBeforeCursor sets paging before cursor
 func (p *Paginator) SetBeforeCursor(beforeCursor string) {
 	p.cursor.Before = &beforeCursor
+}
+
+// SetAllowTupleCmp enables or disables tuple comparison optimization
+func (p *Paginator) SetAllowTupleCmp(allow bool) {
+	p.allowTupleCmp = allow
 }
 
 // Paginate paginates data
@@ -221,13 +227,19 @@ func (p *Paginator) appendPagingQuery(db *gorm.DB, fields []interface{}) *gorm.D
 	stmt := db
 	stmt = stmt.Limit(p.limit + 1)
 	stmt = stmt.Order(p.buildOrderSQL())
-	if len(fields) > 0 {
-		stmt = stmt.Where(
-			p.buildCursorSQLQuery(),
-			p.buildCursorSQLQueryArgs(fields)...,
-		)
+
+	if len(fields) == 0 {
+		return stmt
 	}
-	return stmt
+
+	if p.allowTupleCmp && p.canOptimizePagingQuery() {
+		return stmt.Where(p.buildOptimizedCursorSQLQuery(), fields...)
+	}
+
+	return stmt.Where(
+		p.buildCursorSQLQuery(),
+		p.buildCursorSQLQueryArgs(fields)...,
+	)
 }
 
 func (p *Paginator) buildOrderSQL() string {
@@ -246,17 +258,53 @@ func (p *Paginator) buildCursorSQLQuery() string {
 	queries := make([]string, len(p.rules))
 	query := ""
 	for i, rule := range p.rules {
-		operator := "<"
-		if (p.isForward() && rule.Order == ASC) ||
-			(p.isBackward() && rule.Order == DESC) {
-			operator = ">"
-		}
+		operator := p.getCmpOperator(rule.Order)
 		queries[i] = fmt.Sprintf("%s%s %s ?", query, rule.SQLRepr, operator)
 		query = fmt.Sprintf("%s%s = ? AND ", query, rule.SQLRepr)
 	}
 	// for exmaple:
 	// a > 1 OR a = 1 AND b > 2 OR a = 1 AND b = 2 AND c > 3
 	return strings.Join(queries, " OR ")
+}
+
+// We can only optimize paging query if sorting orders are consistent across
+// all columns used in cursor. This is a prerequisite for tuple comparison that
+// optimized queries use.
+func (p *Paginator) canOptimizePagingQuery() bool {
+	order := p.rules[0].Order
+
+	for _, rule := range p.rules {
+		if order != rule.Order {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (p *Paginator) getCmpOperator(order Order) string {
+	if (p.isForward() && order == ASC) || (p.isBackward() && order == DESC) {
+		return ">"
+	}
+
+	return "<"
+}
+
+func (p *Paginator) buildOptimizedCursorSQLQuery() string {
+	names := make([]string, len(p.rules))
+	values := make([]string, len(p.rules))
+
+	for i, rule := range p.rules {
+		names[i] = rule.SQLRepr
+		values[i] = "?"
+	}
+
+	return fmt.Sprintf(
+		"(%s) %s (%s)",
+		strings.Join(names, ", "),
+		p.getCmpOperator(p.rules[0].Order),
+		strings.Join(values, ", "),
+	)
 }
 
 func (p *Paginator) buildCursorSQLQueryArgs(fields []interface{}) (args []interface{}) {

--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -233,7 +233,7 @@ func (p *Paginator) appendPagingQuery(db *gorm.DB, fields []interface{}) *gorm.D
 	}
 
 	if p.allowTupleCmp && p.canOptimizePagingQuery() {
-		return stmt.Where(p.buildOptimizedCursorSQLQuery(), fields...)
+		return stmt.Where(p.buildOptimizedCursorSQLQuery(), fields)
 	}
 
 	return stmt.Where(
@@ -292,18 +292,15 @@ func (p *Paginator) getCmpOperator(order Order) string {
 
 func (p *Paginator) buildOptimizedCursorSQLQuery() string {
 	names := make([]string, len(p.rules))
-	values := make([]string, len(p.rules))
 
 	for i, rule := range p.rules {
 		names[i] = rule.SQLRepr
-		values[i] = "?"
 	}
 
 	return fmt.Sprintf(
-		"(%s) %s (%s)",
+		"(%s) %s ?",
 		strings.Join(names, ", "),
 		p.getCmpOperator(p.rules[0].Order),
-		strings.Join(values, ", "),
 	)
 }
 


### PR DESCRIPTION
Current implementation of pagination on composite cursors is rather inneficient on large tables even in the presence of index. Changes in this commit add an optimization option that causes paginator to emit a bit different WHERE condition that query optimizators have an easier time optimizing.

We kept changes backward-compatible. We need to opt-in to get the new feature enabled.